### PR TITLE
Add a failOnError method

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,18 @@ gulp.task('lint', function() {
         .pipe(lesshint({
             // Options
         }))
-        .pipe(lesshint.reporter('reporter-name')); // Leave empty to use the default, "stylish"
+        .pipe(lesshint.reporter('reporter-name')) // Leave empty to use the default, "stylish"
+        .pipe(lesshint.failOnError()); // Use this to fail the task on lint errors
 });
 ```
 
 ## Options
 * `configPath`
     * Pass a path to a valid configuration file and stop lesshint from looking for a `.lesshintrc` file.
+
+## API
+* `lesshint.failOnError()`
+    * Use this to fail the task when there are at least one lint result with a severity of `error`.
 
 ## Reporters
 If no reporter name is passed, the default `lesshint-reporter-stylish` will be used which just prints everything with different colors.

--- a/index.js
+++ b/index.js
@@ -92,4 +92,32 @@ lesshintPlugin.reporter = function (reporter) {
     });
 };
 
+lesshintPlugin.failOnError = function () {
+    var errorCount = 0;
+
+    return through.obj(function (file, enc, cb) {
+        file.lesshint.results.forEach(function (result) {
+            if (result.severity === 'error') {
+                errorCount++;
+            }
+        });
+
+        return cb(null, file);
+    }, function (cb) {
+        var message;
+
+        if (!errorCount) {
+            return;
+        }
+
+        message = 'Failed with ' + errorCount + (errorCount === 1 ? ' error' : ' errors');
+
+        this.emit('error', new PluginError('gulp-lesshint', message, {
+            name: 'LesshintError'
+        }));
+
+        return cb();
+    });
+};
+
 module.exports = lesshintPlugin;

--- a/test/config.json
+++ b/test/config.json
@@ -1,5 +1,9 @@
 {
     "excludedFiles": ["exclude.less"],
 
-    "spaceBeforeBrace": false
+    "spaceBeforeBrace": false,
+    "spaceAfterPropertyColon": {
+        "enabled": true,
+        "severity": "error"
+    }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -80,6 +80,8 @@ describe('gulp-lesshint', function () {
         reporterStream.once('end', function () {
             assert.ok(console.log.called);
 
+            console.log.restore();
+
             cb();
         });
 
@@ -114,6 +116,37 @@ describe('gulp-lesshint', function () {
         }));
 
         stream.end();
+    });
+
+    it('should emit errors when asked to', function (cb) {
+        var lintStream = lesshint({
+            configPath: './test/config.json'
+        });
+        var failStream = lesshint.failOnError();
+
+        lintStream.on('data', function (file) {
+            failStream.write(file);
+        });
+
+        lintStream.once('end', function () {
+            failStream.end();
+        });
+
+        failStream.on('data', function () {});
+
+        failStream.on('error', function (error) {
+            assert.equal(error.name, 'LesshintError');
+
+            cb();
+        });
+
+        lintStream.write(new File({
+            base: __dirname,
+            path: __dirname + '/fixture.less',
+            contents: new Buffer('.foo {\ncolor:red;\n}\n')
+        }));
+
+        lintStream.end();
     });
 
     it('should ignore null files', function () {


### PR DESCRIPTION
I'd like some feedback on this. Good, bad, something else? Let me know!

Sample usage
```js
var gulp = require('gulp');
var lesshint = require('gulp-lesshint');

gulp.task('lint', function() {
    return gulp.src('./src/*.less')
        .pipe(lesshint())
        .pipe(lesshint.reporter())
        .pipe(lesshint.failOnError());
});
```

Closes #13.