### PR TITLE
Add "end" event emitter to `failOnErrors()` so that it will work with merged streams

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,8 +104,7 @@ lesshintPlugin.failOnError = function () {
         return cb(null, file);
     }, function (cb) {
         if (!errorCount) {
-            this.emit('end');
-            return;
+            return cb();
         }
 
         const message = `Failed with ${ errorCount } ` + (errorCount === 1 ? 'error' : 'errors');

--- a/index.js
+++ b/index.js
@@ -104,6 +104,7 @@ lesshintPlugin.failOnError = function () {
         return cb(null, file);
     }, function (cb) {
         if (!errorCount) {
+            this.emit('end');
             return;
         }
 


### PR DESCRIPTION
First, thanks for the open-source work you've done 👍 

I'd like to propose adding an event emitter when the combination of using `failOnError` and zero errors are reported occur in a pipeline. 

Currently, if you use a module like [merge-stream](https://www.npmjs.com/package/merge-stream), and create a gulp task like this (where "lessHintTask" internally relies on gulp-lesshint with a `.pipe(lesshint.failOnError())`):

```
gulp.task('taskName', () => {
    return mergeStream(
      'subtaskOne',
      'subtaskTwo,
      'lessHintTask')
  })
```

If zero errors are reported, the stream never ends and merge-stream never completes which leaves the task open.

Thanks for your consideration