### PR TITLE
Fixed the issue with not showing the report with exceeding total number of warnings

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,11 +4,12 @@ const PluginError = require('plugin-error');
 const Lesshint = require('lesshint').Lesshint;
 const through = require('through2');
 
-let warningCount = 0;
+let warningCount;
 let maxWarnings;
 
 const lesshintPlugin = (options) => {
     const lesshint = new Lesshint();
+    warningCount = 0;
 
     options = options || {};
 

--- a/index.js
+++ b/index.js
@@ -93,7 +93,7 @@ lesshintPlugin.failOnError = () => {
 
         return cb(null, file);
     }, function (cb) {
-        if (!errorCount || warningCount - maxWarnings <= 0) {
+        if (errorCount || warningCount - maxWarnings <= 0) {
             return cb();
         }
 

--- a/index.js
+++ b/index.js
@@ -94,7 +94,7 @@ lesshintPlugin.failOnError = () => {
 
         return cb(null, file);
     }, function (cb) {
-        if (errorCount || warningCount - maxWarnings <= 0) {
+        if (!errorCount && warningCount - maxWarnings <= 0) {
             return cb();
         }
 

--- a/test/test.js
+++ b/test/test.js
@@ -180,7 +180,13 @@ describe('gulp-lesshint', () => {
             maxWarnings: 1
         });
 
-        stream.on('error', (error) => {
+        const failStream = lesshint.failOnError();
+
+        stream.on('data', (file) => {
+            failStream.write(file);
+        });
+
+        failStream.on('error', (error) => {
             assert.equal(error.message, 'Failed with 3 warnings. Maximum allowed is 1.');
 
             cb();


### PR DESCRIPTION
Hey!
Thanks for the nice library, I was happy that it is actually already existed.
I would like to incorporate some changes.
* First one it to be able to throw exception when at least 1 warning is found, currently that's not possible because of this check:
https://github.com/lesshint/gulp-lesshint/blob/33bd64ccf87a230a06963f8903ec5818b023247a/index.js#L20
As javascript interprets 0 as false, and therefore no limit is set then.
* Second issue is if to set any maxWarnings threshold there is no way to see actual reports what went wrong. Just telling the user that 15 warnings are found is not very informative :) And also just show warnings and not fail a build - will not force all participants to adhere to a quality.

If you have any concerns, questions, please shoot! :) 

