### PR TITLE
Extract utility functions to utils.js

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -3,6 +3,16 @@
 const minimatch = require('minimatch');
 
 module.exports = {
+    getSeverityCount (results, isSeverityFn) {
+        return results.reduce((sum, result) => {
+            return sum + (isSeverityFn(result.severity) ? 1 : 0);
+        }, 0);
+    },
+
+    isError (severity) {
+        return severity === 'error';
+    },
+
     isExcluded (config, checkPath) {
         const excludedFiles = config && config.excludedFiles || [];
 
@@ -11,5 +21,13 @@ module.exports = {
                 matchBase: true,
             });
         });
+    },
+
+    isWarning (severity) {
+        return severity === 'warning';
+    },
+
+    pluralize (singular, count) {
+        return count === 1 ? singular : `${ singular }s`;
     },
 };


### PR DESCRIPTION
Related to the conversation on https://github.com/lesshint/gulp-lesshint/pull/39, this is pre-work to adding a `failOnWarning()` method to the plugin.

Extracted util methods: `getSeverityCount`, `isError`, `isWarning`, and `pluralize`.

Lint free and all tests are passing. I tried to maintain the existing style. One thing of note, I made the use of a dangling comma consistent as that was used in most existing cases, just not all.