### PR TITLE
Add failOnWarning support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ gulp.task('lint', () => {
             // Options
         }))
         .pipe(lesshint.reporter('reporter-name')) // Leave empty to use the default, "stylish"
-        .pipe(lesshint.failOnError()); // Use this to fail the task on lint errors
+        .pipe(lesshint.failOnError()) // Use this to fail the task on lint errors
         .pipe(lesshint.failOnWarning()); // Use this to fail the task on lint warnings
 });
 ```

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ gulp.task('lint', () => {
         }))
         .pipe(lesshint.reporter('reporter-name')) // Leave empty to use the default, "stylish"
         .pipe(lesshint.failOnError()); // Use this to fail the task on lint errors
+        .pipe(lesshint.failOnWarning()); // Use this to fail the task on lint warnings
 });
 ```
 
@@ -30,6 +31,8 @@ gulp.task('lint', () => {
 ## API
 * `lesshint.failOnError()`
     * Use this to fail the task when there are at least one lint result with a severity of `error`.
+* `lesshint.failOnWarning()`
+    * Use this to fail the task when there are at least one lint result with a severity of `warning`.**NOTE**: this does not respect the `maxWarnings` option.
 
 ## Reporters
 If no reporter name is passed, the default `lesshint-reporter-stylish` will be used which just prints everything with different colors.

--- a/index.js
+++ b/index.js
@@ -108,4 +108,28 @@ lesshintPlugin.failOnError = () => {
     });
 };
 
+lesshintPlugin.failOnWarning = () => {
+    let warningCount = 0;
+
+    return through.obj((file, enc, cb) => {
+        if (file.lesshint) {
+            warningCount += severityCount(file.lesshint.results, isWarning);
+        }
+
+        return cb(null, file);
+    }, function (cb) {
+        if (!warningCount) {
+            return cb();
+        }
+
+        const message = `Failed with ${ warningCount } ${ pluralize('warning', warningCount) }`;
+
+        this.emit('error', new PluginError('gulp-lesshint', message, {
+            name: 'LesshintError',
+        }));
+
+        return cb();
+    });
+};
+
 module.exports = lesshintPlugin;

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const PluginError = require('plugin-error');
 const Lesshint = require('lesshint').Lesshint;
 const through = require('through2');
 
-const { getSeverityCount, isError, isExcluded, isWarning, pluralize } = require('./utils');
+const { isError, isExcluded, isWarning, pluralize, severityCount } = require('./utils');
 
 const lesshintPlugin = (options = {}) => {
     const lesshint = new Lesshint();
@@ -33,7 +33,7 @@ const lesshintPlugin = (options = {}) => {
             const contents = file.contents.toString();
             const results = lesshint.checkString(contents, file.path);
 
-            warningCount += getSeverityCount(results, isWarning);
+            warningCount += severityCount(results, isWarning);
 
             file.lesshint = {
                 resultCount: results.length,
@@ -89,7 +89,7 @@ lesshintPlugin.failOnError = () => {
 
     return through.obj((file, enc, cb) => {
         if (file.lesshint) {
-            errorCount += getSeverityCount(file.lesshint.results, isError);
+            errorCount += severityCount(file.lesshint.results, isError);
         }
 
         return cb(null, file);

--- a/test/test.js
+++ b/test/test.js
@@ -140,7 +140,7 @@ describe('gulp-lesshint', () => {
         stream.end();
     });
 
-    it('should emit errors when asked to', (cb) => {
+    it('should fail on errors when asked to', (cb) => {
         const lintStream = lesshint({
             configPath: './test/config.json'
         });
@@ -168,6 +168,41 @@ describe('gulp-lesshint', () => {
             contents: Buffer.from(`
                 .foo {
                     color:red;
+                }
+            `)
+        }));
+
+        lintStream.end();
+    });
+
+    it('should fail on warnings when asked to', (cb) => {
+        const lintStream = lesshint({
+            configPath: './test/config.json'
+        });
+        const failStream = lesshint.failOnWarning();
+
+        lintStream.on('data', (file) => {
+            failStream.write(file);
+        });
+
+        lintStream.once('end', () => {
+            failStream.end();
+        });
+
+        failStream.on('data', () => {});
+
+        failStream.on('error', (error) => {
+            assert.equal(error.name, 'LesshintError');
+
+            cb();
+        });
+
+        lintStream.write(new File({
+            base: __dirname,
+            path: __dirname + '/fixture.less',
+            contents: Buffer.from(`
+                .foo {
+                    color: red !important;
                 }
             `)
         }));

--- a/utils.js
+++ b/utils.js
@@ -3,12 +3,6 @@
 const minimatch = require('minimatch');
 
 module.exports = {
-    getSeverityCount (results, isSeverityFn) {
-        return results.reduce((sum, result) => {
-            return sum + (isSeverityFn(result.severity) ? 1 : 0);
-        }, 0);
-    },
-
     isError (severity) {
         return severity === 'error';
     },
@@ -29,5 +23,11 @@ module.exports = {
 
     pluralize (singular, count) {
         return count === 1 ? singular : `${ singular }s`;
+    },
+
+    severityCount (results, isSeverityFn) {
+        return results.reduce((sum, result) => {
+            return sum + (isSeverityFn(result.severity) ? 1 : 0);
+        }, 0);
     },
 };


### PR DESCRIPTION
Add support to fail on warnings as a pipeline step. This does not modify nor use the existing 'maxWarnings' option.

Related to conversation on https://github.com/lesshint/gulp-lesshint/pull/39